### PR TITLE
suzuran: Update NFC NXP HAL naming

### DIFF
--- a/aosp_e5823.mk
+++ b/aosp_e5823.mk
@@ -40,6 +40,10 @@ PRODUCT_COPY_FILES += \
     device/sony/suzuran/rootdir/system/etc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
     device/sony/suzuran/rootdir/system/etc/mixer_paths.xml:system/etc/mixer_paths.xml
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.suzuran
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=suzuran
+
 PRODUCT_NAME := aosp_e5823
 PRODUCT_DEVICE := suzuran
 PRODUCT_MODEL := Xperia Z5 Compact (AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba humberos@gmail.com
