### PR TITLE
re-enable TapToWake support

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -89,4 +89,7 @@
          in darkness (although they may not be visible in a bright room). -->
     <integer name="config_screenBrightnessDark">5</integer>
 
+    <!-- Whether device supports double tap to wake -->
+    <bool name="config_supportDoubleTapWake">true</bool>
+
 </resources>


### PR DESCRIPTION
was removed from common here: sonyxperiadev/device-sony-common@a90c24e

Signed-off-by: David Viteri davidteri91@gmail.com
