### PR TITLE
suzuran: move mms_useragent per device from common

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -20,7 +20,6 @@
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds.  Do not translate. -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-
     <!-- Array of light sensor LUX values to define our levels for auto backlight brightness support.
          The N entries of this array define N  1 zones as follows:
 
@@ -105,4 +104,6 @@
          The default is false. -->
     <bool name="config_lidControlsSleep">true</bool>
 
+    <!-- MMS user agent prolfile url -->
+    <string name="config_mms_user_agent_profile_url" translatable="false">http://uaprof.sonymobile.com/E5803R3211.xml</string>
 </resources>


### PR DESCRIPTION
this should be info per target and not common

Signed-off-by: David Viteri davidteri91@gmail.com
